### PR TITLE
Make tests work with both Go 1.13 and 1.14.

### DIFF
--- a/disco/host_test.go
+++ b/disco/host_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -283,12 +284,12 @@ func TestHostServiceOAuthClient(t *testing.T) {
 		{
 			"invalidauthz.v1",
 			nil,
-			"Failed to parse authorization URL: parse ***not A URL at all!:/<@@@@>***: first path segment in URL cannot contain colon",
+			`Failed to parse authorization URL: parse "?\*\*\*not A URL at all!:/<@@@@>\*\*\*"?: first path segment in URL cannot contain colon`,
 		},
 		{
 			"invalidtoken.v1",
 			nil,
-			"Failed to parse token URL: parse ***not A URL at all!:/<@@@@>***: first path segment in URL cannot contain colon",
+			`Failed to parse token URL: parse "?\*\*\*not A URL at all!:/<@@@@>\*\*\*"?: first path segment in URL cannot contain colon`,
 		},
 	}
 
@@ -296,7 +297,7 @@ func TestHostServiceOAuthClient(t *testing.T) {
 		t.Run(test.ID, func(t *testing.T) {
 			got, err := host.ServiceOAuthClient(test.ID)
 			if (err != nil || test.err != "") &&
-				(err == nil || !strings.Contains(err.Error(), test.err)) {
+				(err == nil || !regexp.MustCompile(test.err).MatchString(err.Error())) {
 				t.Fatalf("unexpected service URL error: %s", err)
 			}
 


### PR DESCRIPTION
Some tests failed with Go 1.14 due to reliance on the exact text of "net/url".Error errors.
Go 1.14 quotes the text of the URL in errors to improve clarity when the URL contains spaces.

For example:

  Go 1.13: parse  http://example.org: first path segment in URL cannot contain colon
  Go 1.14: parse " http://example.org": first path segment in URL cannot contain colon