### PR TITLE
ci: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels: ["dependencies"]


### PR DESCRIPTION
We use dependabot to keep dependencies up to date and receive timely updates in most other projects which also depend on this library and it would be great to automate this task at least partially.

For posterity - PRs bumping dependencies will be still subject to human reviews but it reduces the overall effort as humans don't need to raise the PRs and monitor dependency tree.
