### PR TITLE
svchost: Specialized error for using a URL as a hostname

### DIFF
--- a/svchost.go
+++ b/svchost.go
@@ -101,6 +101,18 @@ func ForComparison(given string) (Hostname, error) {
 	var err error
 	portPortion, err = normalizePortPortion(portPortion)
 	if err != nil {
+		// We can get in here if someone has incorrectly specified a URL
+		// instead of a hostname, because normalizePortPortion will try to
+		// treat the colon after the scheme as the port number separator.
+		// We'll return a more specific error message for that situation.
+		given = strings.ToLower(given)
+		if given == "https" || given == "http" {
+			// Technically it's valid to have a host called "https" or "http"
+			// which would generate a false positive here with input like
+			// "http:foo", but we can only get here if the hostname exactly
+			// matches one of the schemes _and_ the port number is also invalid.
+			return Hostname(""), fmt.Errorf("need just a hostname and optional port number, not a full URL")
+		}
 		return Hostname(""), err
 	}
 


### PR DESCRIPTION
There are various reasons why someone might accidentally use a full URL where we expect a hostname. For example, copying a hostname from the location bar of a modern web browser tends to silently add the scheme to the content on the clipboard even though it wasn't disclosed in the UI.

To help diagnose that we'll catch that as a special case and return a tailored error message for it. The heuristic here is to detech when both the port number is invalid and when the apparent hostname is "http" and "https", which should hopefully be loose enough to show this message where it's helpful (even accommodating slightly-invalid URLs) but minimize false positives where it might be misleading advice.

This was motivated by hashicorp/terraform#32319 but won't actually close it until there's a corresponding change in the Terraform repository to upgrade to a newer version of this library.
