### PR TITLE
Add host aliasing to service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terraform svchost package
+# terraform-svchost
 
 [![CI Tests](https://github.com/hashicorp/terraform-svchost/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hashicorp/terraform-svchost/actions/workflows/ci.yml)
 [![GitHub license](https://img.shields.io/github/license/hashicorp/terraform-svchost.svg)](https://github.com/hashicorp/terraform-svchost/blob/main/LICENSE)

--- a/disco/disco.go
+++ b/disco/disco.go
@@ -10,14 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/hashicorp/terraform-svchost"
+	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 )
 
@@ -42,6 +41,7 @@ var httpTransport = defaultHttpTransport()
 // hostnames and caches the results by hostname to avoid repeated requests
 // for the same information.
 type Disco struct {
+	aliases   map[svchost.Hostname]svchost.Hostname
 	hostCache map[svchost.Hostname]*Host
 	credsSrc  auth.CredentialsSource
 
@@ -69,6 +69,7 @@ func New() *Disco {
 // the given credentials source.
 func NewWithCredentialsSource(credsSrc auth.CredentialsSource) *Disco {
 	return &Disco{
+		aliases:   make(map[svchost.Hostname]svchost.Hostname),
 		hostCache: make(map[svchost.Hostname]*Host),
 		credsSrc:  credsSrc,
 		Transport: httpTransport,
@@ -104,10 +105,14 @@ func (d *Disco) CredentialsSource() auth.CredentialsSource {
 }
 
 // CredentialsForHost returns a non-nil HostCredentials if the embedded source has
-// credentials available for the host, and a nil HostCredentials if it does not.
+// credentials available for the host, or host alias, and a nil HostCredentials if it does not.
 func (d *Disco) CredentialsForHost(hostname svchost.Hostname) (auth.HostCredentials, error) {
 	if d.credsSrc == nil {
 		return nil, nil
+	}
+	if aliasedHost, aliasExists := d.aliases[hostname]; aliasExists {
+		log.Printf("[DEBUG] CredentialsForHost found alias %s for %s", hostname, aliasedHost)
+		hostname = aliasedHost
 	}
 	return d.credsSrc.ForHost(hostname)
 }
@@ -137,6 +142,13 @@ func (d *Disco) ForceHostServices(hostname svchost.Hostname, services map[string
 		services:  services,
 		transport: d.Transport,
 	}
+}
+
+// Alias accepts an alias and target Hostname. When service discovery is performed
+// or credentials are requested for the alias hostname, the target will be consulted instead.
+func (d *Disco) Alias(alias, target svchost.Hostname) {
+	log.Printf("[DEBUG] Service discovery for %s aliased as %s", target, alias)
+	d.aliases[alias] = target
 }
 
 // Discover runs the discovery protocol against the given hostname (which must
@@ -176,6 +188,11 @@ func (d *Disco) DiscoverServiceURL(hostname svchost.Hostname, serviceID string) 
 // discover implements the actual discovery process, with its result cached
 // by the public-facing Discover method.
 func (d *Disco) discover(hostname svchost.Hostname) (*Host, error) {
+	if aliasedHost, aliasExists := d.aliases[hostname]; aliasExists {
+		log.Printf("[DEBUG] Discover found alias %s for %s", hostname, aliasedHost)
+		hostname = aliasedHost
+	}
+
 	discoURL := &url.URL{
 		Scheme: "https",
 		Host:   hostname.String(),
@@ -259,7 +276,7 @@ func (d *Disco) discover(hostname svchost.Hostname) (*Host, error) {
 	// size, but we'll at least prevent reading the entire thing into memory.
 	lr := io.LimitReader(resp.Body, maxDiscoDocBytes)
 
-	servicesBytes, err := ioutil.ReadAll(lr)
+	servicesBytes, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, fmt.Errorf("error reading discovery document body: %v", err)
 	}
@@ -283,4 +300,11 @@ func (d *Disco) Forget(hostname svchost.Hostname) {
 // ForgetAll is like Forget, but for all of the hostnames that have cache entries.
 func (d *Disco) ForgetAll() {
 	d.hostCache = make(map[svchost.Hostname]*Host)
+}
+
+// ForgetAlias removes a previously aliased hostname as well as its cached entry, if any exist.
+// If the alias has no target then this is a no-op.
+func (d *Disco) ForgetAlias(alias svchost.Hostname) {
+	delete(d.aliases, alias)
+	d.Forget(alias)
 }


### PR DESCRIPTION
## Description

Adds host aliasing, which effectively interprets one host as another for both discovery and credentials lookup.

I implemented this in terraform to alias localterraform.com as my local dev environment and ran terraform init to produce these logs. I've prefixed the relevant ones with **------>**

```
------> 2023-01-25T15:37:04.143-0700 [DEBUG] Service discovery for tfcdev-xxx.ngrok.io aliased as localterraform.com
2023-01-25T15:37:06.763-0700 [DEBUG] New state was assigned lineage "d631ebd8-1d95-24f5-040b-ae32c0af4cb0"
2023-01-25T15:37:06.789-0700 [DEBUG] checking for provisioner in "."
2023-01-25T15:37:06.789-0700 [DEBUG] checking for provisioner in "/Users/brandonc/hashicorp/example-null"
2023-01-25T15:37:06.789-0700 [DEBUG] checking for provisioner in "/Users/brandonc/.terraform.d/plugins"
Initializing modules...
2023-01-25T15:37:09.846-0700 [DEBUG] Module installer: begin stuff
2023-01-25T15:37:09.846-0700 [DEBUG] stuff listing available versions of localterraform.com/hashicorp/simple-s3-cdn/aws at localterraform.com
------> 2023-01-25T15:37:09.846-0700 [DEBUG] Discover found alias localterraform.com for tfcdev-xxx.ngrok.io
------> 2023-01-25T15:37:09.846-0700 [DEBUG] Service discovery for tfcdev-xxx.ngrok.io at https://tfcdev-xxx.ngrok.io/.well-known/terraform.json
2023-01-25T15:37:11.633-0700 [DEBUG] fetching module versions from "https://tfcdev-xxx.ngrok.io/api/registry/v1/modules/hashicorp/simple-s3-cdn/aws/versions"
------> 2023-01-25T15:37:11.633-0700 [DEBUG] CredentialsForHost found alias localterraform.com for tfcdev-xxx.ngrok.io
2023-01-25T15:37:11.633-0700 [DEBUG] GET https://tfcdev-xxx.ngrok.io/api/registry/v1/modules/hashicorp/simple-s3-cdn/aws/versions
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "2.0.0" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "2.0.1" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "1.0.0" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "2.0.2" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "0.1.0" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
2023-01-25T15:37:12.602-0700 [DEBUG] found available version "1.0.1" for tfcdev-xxx.ngrok.io/hashicorp/simple-s3-cdn/aws
Downloading localterraform.com/hashicorp/simple-s3-cdn/aws 2.0.2 for stuff...
2023-01-25T15:37:12.602-0700 [DEBUG] looking up module location from "https://tfcdev-xxx.ngrok.io/api/registry/v1/modules/hashicorp/simple-s3-cdn/aws/2.0.2/download"
------> 2023-01-25T15:37:12.602-0700 [DEBUG] CredentialsForHost found alias localterraform.com for tfcdev-xxx.ngrok.io
2023-01-25T15:37:12.602-0700 [DEBUG] GET https://tfcdev-xxx.ngrok.io/api/registry/v1/modules/hashicorp/simple-s3-cdn/aws/2.0.2/download
2023-01-25T15:37:14.717-0700 [DEBUG] Module installer: stuff installed at .terraform/modules/stuff
- stuff in .terraform/modules/stuff

Initializing provider plugins...
- Reusing previous version of hashicorp/aws from the dependency lock file
2023-01-25T15:37:14.720-0700 [DEBUG] Service discovery for registry.terraform.io at https://registry.terraform.io/.well-known/terraform.json
2023-01-25T15:37:14.788-0700 [DEBUG] GET https://registry.terraform.io/v1/providers/hashicorp/aws/versions
- Reusing previous version of hashicorp/null from the dependency lock file
2023-01-25T15:37:14.961-0700 [DEBUG] GET https://registry.terraform.io/v1/providers/hashicorp/null/versions
2023-01-25T15:37:15.108-0700 [DEBUG] GET https://registry.terraform.io/v1/providers/hashicorp/aws/4.51.0/download/darwin/amd64
2023-01-25T15:37:15.137-0700 [DEBUG] GET https://releases.hashicorp.com/terraform-provider-aws/4.51.0/terraform-provider-aws_4.51.0_SHA256SUMS
2023-01-25T15:37:15.291-0700 [DEBUG] GET https://releases.hashicorp.com/terraform-provider-aws/4.51.0/terraform-provider-aws_4.51.0_SHA256SUMS.72D7468F.sig
- Installing hashicorp/aws v4.51.0...
2023-01-25T15:37:17.349-0700 [DEBUG] Provider signed by 34365D9472D7468F HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>
- Installed hashicorp/aws v4.51.0 (signed by HashiCorp)
2023-01-25T15:37:22.555-0700 [DEBUG] GET https://registry.terraform.io/v1/providers/hashicorp/null/3.2.1/download/darwin/amd64
2023-01-25T15:37:22.590-0700 [DEBUG] GET https://releases.hashicorp.com/terraform-provider-null/3.2.1/terraform-provider-null_3.2.1_SHA256SUMS
2023-01-25T15:37:22.712-0700 [DEBUG] GET https://releases.hashicorp.com/terraform-provider-null/3.2.1/terraform-provider-null_3.2.1_SHA256SUMS.72D7468F.sig
- Installing hashicorp/null v3.2.1...
2023-01-25T15:37:23.126-0700 [DEBUG] Provider signed by 34365D9472D7468F HashiCorp Security (hashicorp.com/security) <security@hashicorp.com>
- Installed hashicorp/null v3.2.1 (signed by HashiCorp)

Terraform Cloud has been successfully initialized!

You may now begin working with Terraform Cloud. Try running "terraform plan" to
see any changes that are required for your infrastructure.

If you ever set or change modules or Terraform Settings, run "terraform init"
again to reinitialize your working directory.
```

