### PR TITLE
Add copywrite headers and GH Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+
 version: 2
 updates:
   - package-ecosystem: "gomod"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,29 @@ on:
       - main
 
 jobs:
+  copywrite:
+    name: Run Header Copyright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Install Copywrite
+        id: install
+        uses: hashicorp/setup-copywrite@v1.0.0
+
+      - name: Output Installed Copywrite Version
+        run: echo "Installed Copywrite CLI ${{steps.install.outputs.version}}"
+
+      - name: Run Copywrite Header Compliance
+        run: copywrite headers --plan
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 // Package auth contains types and functions to manage authentication
 // credentials for service hosts.
 package auth

--- a/auth/from_map.go
+++ b/auth/from_map.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/helper_program.go
+++ b/auth/helper_program.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/helper_program_test.go
+++ b/auth/helper_program_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/static.go
+++ b/auth/static.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/static_test.go
+++ b/auth/static_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/testdata/main.go
+++ b/auth/testdata/main.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package main
 
 import (

--- a/auth/token_credentials.go
+++ b/auth/token_credentials.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/auth/token_credentials_test.go
+++ b/auth/token_credentials_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package auth
 
 import (

--- a/disco/disco.go
+++ b/disco/disco.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 // Package disco handles Terraform's remote service discovery protocol.
 //
 // This protocol allows mapping from a service hostname, as produced by the

--- a/disco/disco_test.go
+++ b/disco/disco_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package disco
 
 import (

--- a/disco/host.go
+++ b/disco/host.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package disco
 
 import (

--- a/disco/host_test.go
+++ b/disco/host_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package disco
 
 import (

--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package disco
 
 import (

--- a/disco/oauth_client.go
+++ b/disco/oauth_client.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package disco
 
 import (

--- a/label_iter.go
+++ b/label_iter.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package svchost
 
 import (

--- a/svchost.go
+++ b/svchost.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 // Package svchost deals with the representations of the so-called "friendly
 // hostnames" that we use to represent systems that provide Terraform-native
 // remote services, such as module registry, remote operations, etc.

--- a/svchost_test.go
+++ b/svchost_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+
 package svchost
 
 import "testing"


### PR DESCRIPTION
### :hammer_and_wrench: Description

<!-- What code changed, and why? What are the key new features or breaking changes? -->
* HashiCorp public repos will begin being scanned for source code copyright headers starting Feb.1, 2023. We want to make sure this repo is in adherence to the automated checks.
* Add Github action which will run a check on the repo during pull requests. This is simply a validation and will not automatically correct any source.
* Bring repo up-to-date using the `copywrite` CLI.

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->
* [GH Action](https://github.com/marketplace/actions/setup-copywrite)
* `copywrite` [CLI](https://github.com/hashicorp/copywrite#getting-started)
