### PR TITLE
Bump copywrite to version 1.1.2 to address rate limit error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install Copywrite
         id: install
-        uses: hashicorp/setup-copywrite@v1.0.0
+        uses: hashicorp/setup-copywrite@v1.1.2
 
       - name: Output Installed Copywrite Version
         run: echo "Installed Copywrite CLI ${{steps.install.outputs.version}}"


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/terraform-svchost! Please read CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

A previous version of [setup-copywrite](https://github.com/hashicorp/setup-copywrite) had rate limited related errors. These should be addressed in the latest version, so bumping to `1.1.2`.

## Testing plan

Tests should pass
