### PR TITLE
Add support for mirror registries behind mutual TLS

### DIFF
--- a/auth/mtls_credentials.go
+++ b/auth/mtls_credentials.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// HostCredentialsMTLS is a HostCredentials implementation that represents
+// mTLS (Mutual TLS) credentials, using client certificates and keys.
+// It can also include a bearer token for application-level authorization.
+type HostCredentialsMTLS struct {
+	ClientCert    string
+	ClientKey     string
+	CACertificate string
+	TokenValue    string
+}
+
+// Ensure HostCredentialsMTLS implements HostCredentialsExtended
+var _ HostCredentialsExtended = &HostCredentialsMTLS{}
+
+// PrepareRequest prepares the HTTP request by setting the Authorization
+// header and configuring mTLS if available.
+func (c *HostCredentialsMTLS) PrepareRequest(req *http.Request) {
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+
+	// Set the Authorization header if a token is present
+	if c.TokenValue != "" {
+		req.Header.Set("Authorization", "Bearer "+c.TokenValue)
+	}
+
+	// Note: The actual mTLS setup usually happens at the transport layer,
+	// which is outside the scope of this PrepareRequest method.
+}
+
+// GetTLSConfig returns a TLS configuration for mTLS authentication.
+func (c *HostCredentialsMTLS) GetTLSConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(c.ClientCert, c.ClientKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	if c.CACertificate != "" {
+		caCert, err := os.ReadFile(c.CACertificate)
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, err
+		}
+
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	return tlsConfig, nil
+}
+
+// Token returns the bearer token associated with the credentials.
+func (c *HostCredentialsMTLS) Token() string {
+	return c.TokenValue
+}
+
+// SetToken sets the token value for the credentials.
+func (c *HostCredentialsMTLS) SetToken(token string) {
+	c.TokenValue = token
+}
+
+// ToStore serializes the mTLS credentials and token for storage.
+func (c *HostCredentialsMTLS) ToStore() cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"client_cert": cty.StringVal(c.ClientCert),
+		"client_key":  cty.StringVal(c.ClientKey),
+		"ca_cert":     cty.StringVal(c.CACertificate),
+		"token":       cty.StringVal(c.TokenValue),
+	})
+}

--- a/auth/mtls_credentials_test.go
+++ b/auth/mtls_credentials_test.go
@@ -1,0 +1,137 @@
+package auth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func generateSelfSignedCert() (certFile, keyFile string, err error) {
+	// Generate a private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Create a self-signed certificate
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Organization"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Encode the certificate and key to PEM format
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return "", "", err
+	}
+	keyPEMBytes := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyPEM})
+
+	// Write the certificate and key to temporary files
+	certTempFile, err := os.CreateTemp("", "cert.pem")
+	if err != nil {
+		return "", "", err
+	}
+	defer certTempFile.Close()
+	if _, err := certTempFile.Write(certPEM); err != nil {
+		return "", "", err
+	}
+
+	keyTempFile, err := os.CreateTemp("", "key.pem")
+	if err != nil {
+		return "", "", err
+	}
+	defer keyTempFile.Close()
+	if _, err := keyTempFile.Write(keyPEMBytes); err != nil {
+		return "", "", err
+	}
+
+	return certTempFile.Name(), keyTempFile.Name(), nil
+}
+
+func TestHostCredentialsMTLS(t *testing.T) {
+	// Generate self-signed cert and key
+	certFile, keyFile, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("failed to generate self-signed cert: %v", err)
+	}
+	defer os.Remove(certFile)
+	defer os.Remove(keyFile)
+
+	creds := &HostCredentialsMTLS{
+		ClientCert:    certFile,
+		ClientKey:     keyFile,
+		CACertificate: "", // optional CA
+		TokenValue:    "foo-bar",
+	}
+
+	// Test PrepareRequest
+	t.Run("PrepareRequest", func(t *testing.T) {
+		req := &http.Request{Header: make(http.Header)}
+		creds.PrepareRequest(req)
+		authStr := req.Header.Get("Authorization")
+		if got, want := authStr, "Bearer foo-bar"; got != want {
+			t.Errorf("wrong Authorization header value %q; want %q", got, want)
+		}
+	})
+
+	// Test GetTLSConfig
+	t.Run("GetTLSConfig", func(t *testing.T) {
+		tlsConfig, err := creds.GetTLSConfig()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Check if tlsConfig is nil, which would indicate a problem
+		if tlsConfig == nil {
+			t.Fatalf("tlsConfig is nil; expected a valid TLS configuration")
+		}
+
+		if len(tlsConfig.Certificates) != 1 {
+			t.Errorf("expected 1 certificate, got %d", len(tlsConfig.Certificates))
+		}
+
+		// Further checks can be added to validate the loaded certificates,
+		// but those would typically require actual files and might be more
+		// suitable for integration tests.
+	})
+
+	// Test ToStore
+	t.Run("ToStore", func(t *testing.T) {
+		got := creds.ToStore()
+		want := cty.ObjectVal(map[string]cty.Value{
+			"client_cert": cty.StringVal(certFile),
+			"client_key":  cty.StringVal(keyFile),
+			"ca_cert":     cty.StringVal(""),
+			"token":       cty.StringVal("foo-bar"),
+		})
+		if !want.RawEquals(got) {
+			t.Errorf("wrong storable object value\ngot:  %#v\nwant: %#v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/terraform-svchost! Please read CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR introduces an enhancement by adding mutual TLS (mTLS) support for service host mirroring. This feature has been requested in https://github.com/hashicorp/terraform/issues/32110 

Background: some companies have internal policy to place **any** services behind mutual TLS which makes it hardly possible to use private registries such as JFrog, so that https://jfrog.com/help/r/jfrog-artifactory-documentation/use-terraform-module-registries is not feasible to make use of since Terraform currently doesn't support specifying connections with client TLS authentication. These changes are going to address this shortage and have been successfully tested internally. Note the patch is for the latest released version tag i.e. 0.1.1 and not the main branch.

Key Changes:

mTLS Support: Implemented mTLS support for service host mirroring, allowing secure, authenticated connections to mirrored service endpoints.
Configuration Options: Added configuration settings to enable and manage mTLS for specific services, including specifying client certificates and CA bundles.
Error Handling Improvements: Enhanced error handling to provide better feedback when mTLS connections fail, making debugging easier.
Backward Compatibility: This update is backward compatible. Non-mTLS connections will continue to function as before unless mTLS is explicitly enabled.

## Testing plan

Tests are added for the newly introduced interface `HostCredentialsExtended` related code.

## External links

https://github.com/hashicorp/terraform/issues/32110
