### PR TITLE
Add data dictionary

### DIFF
--- a/META.d/data.yaml
+++ b/META.d/data.yaml
@@ -1,0 +1,4 @@
+data_summary:
+  gdpr:
+    exempt: true
+    last_reviewed: 2024-11-04

--- a/META.d/data.yaml
+++ b/META.d/data.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) HashiCorp, Inc.
+
 data_summary:
   gdpr:
     exempt: true


### PR DESCRIPTION
## Description

Adds a data dictionary noting that this repo/service is exempt from GDPR reporting (as it doesn't persist personally identifiable info)

For reference, here are similar files from across the Hashicorp org: https://github.com/search?q=org%3Ahashicorp+meta.d%2Fdata.yaml&type=code&p=1

## External links

JIRA: https://hashicorp.atlassian.net/browse/TF-21756?atlOrigin=eyJpIjoiMTM2ZTJiMjRjMmIxNGE4MThlMzIzYTc2MzAxMTBlMjMiLCJwIjoiaiJ9
