### PR TITLE
Hedged http requests for service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.2.0
+
+#### Enhancements
+
+Highly latent requests during service discovery are rare but happen many times per day. Service discovery now implements a hedged request strategy, where the service discovery request is repeated up to 7 times at 1500 ms intervals until the server responds.
+
 ## v0.1.1
 
 The `disco.Disco` and `auth.CachingCredentialsSource` implementations are now safe for concurrent calls. Previously concurrent calls could potentially corrupt the internal cache maps or cause the Go runtime to panic.

--- a/disco/disco.go
+++ b/disco/disco.go
@@ -31,8 +31,9 @@ const (
 	// Arbitrary-but-small number to prevent runaway redirect loops.
 	maxRedirects = 3
 
-	// Arbitrary-but-small time limit to prevent UI "hangs" during discovery.
-	discoTimeout = 11 * time.Second
+	// This timeout should very seldom be needed- it would depend on the server
+	// being very slow or unresponsive for seven consecutive hedged requests.
+	discoTimeout = 15 * time.Second
 
 	// Interval between hedged requests.
 	hedgeTimeout = 1500 * time.Millisecond

--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -3,26 +3,118 @@
 package disco
 
 import (
+	"context"
 	"net/http"
-
-	"github.com/hashicorp/go-cleanhttp"
+	"time"
 )
 
+// DefaultUserAgent is the default User-Agent header value used in requests.
 const DefaultUserAgent = "terraform-svchost/1.0"
 
-func defaultHTTPTransport() http.RoundTripper {
-	t := cleanhttp.DefaultPooledTransport()
-	return &userAgentRoundTripper{
-		innerRt:   t,
-		userAgent: DefaultUserAgent,
-	}
-}
-
+// userAgentRoundTripper is an http.RoundTripper that adds a User-Agent header
+// to requests.
 type userAgentRoundTripper struct {
 	innerRt   http.RoundTripper
 	userAgent string
 }
 
+// hedgedTransport implements a hedged HTTP transport that sends multiple
+// requests if a previous request takes too long, with a specified timeout
+// between attempts.
+type hedgedTransport struct {
+	// Transport is the underlying RT used to actually make the requests.
+	transport http.RoundTripper
+	// Timeout is the interval between initiating hedged requests.
+	timeout time.Duration
+	// MaxAttempts is the total number of requests (1 original + n-1 hedges).
+	maxAttempts int
+}
+
+// newHedgedHTTPTransport creates a new hedgedTransport with the specified timings
+func newHedgedHTTPTransport(transport http.RoundTripper, hedgeTimeout time.Duration, upTo int) http.RoundTripper {
+	return &hedgedTransport{
+		transport:   transport,
+		timeout:     hedgeTimeout,
+		maxAttempts: upTo,
+	}
+}
+
+// newUserAgentTransport creates a new userAgentRoundTripper with the given ua string
+func newUserAgentTransport(userAgent string, innerRt http.RoundTripper) http.RoundTripper {
+	return &userAgentRoundTripper{
+		innerRt:   innerRt,
+		userAgent: userAgent,
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface for hedgedTransport
+func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// We use a shared context to cancel all outstanding requests
+	// once the first one returns successfully.
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	type result struct {
+		res *http.Response
+		err error
+	}
+
+	// Buffer the channel to prevent goroutine leaks.
+	results := make(chan result, ht.maxAttempts)
+
+	runAttempt := func() {
+		outReq := req.Clone(ctx)
+		resp, err := ht.transport.RoundTrip(outReq)
+
+		// handle the error case downstream
+		select {
+		case results <- result{resp, err}:
+		case <-ctx.Done():
+			// If context is canceled, someone else won.
+			// Ensure we don't leak the response body.
+			if resp != nil && resp.Body != nil {
+				resp.Body.Close()
+			}
+		}
+	}
+	go runAttempt()
+	var lastErr error
+	started := 1
+	received := 0
+
+	for {
+		var timeout <-chan time.Time
+
+		// if we haven't started all attempts, use ht.timeout.
+		// if we have, wait indefinitely (effectively until context cancel).
+		if started < ht.maxAttempts {
+			timeout = time.After(ht.timeout)
+		}
+		select {
+		case res := <-results:
+			received++
+			if res.err == nil {
+				return res.res, nil
+			}
+			// Don't leak response bodies
+			if res.res != nil && res.res.Body != nil {
+				res.res.Body.Close()
+			}
+			lastErr = res.err
+			// If all attempts we started have failed AND we've reached the limit
+			if received == ht.maxAttempts {
+				return nil, lastErr
+			}
+		case <-timeout:
+			started++
+			go runAttempt()
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface for userAgentRoundTripper
 func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if _, ok := req.Header["User-Agent"]; !ok {
 		req.Header.Set("User-Agent", rt.userAgent)

--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -93,7 +93,8 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		select {
 		case res := <-results:
 			received++
-			if res.err == nil {
+			// Retry on error (no response) or 5xx
+			if res.err == nil && res.res.StatusCode < 500 {
 				return res.res, nil
 			}
 			// Don't leak response bodies

--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -104,7 +104,7 @@ func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 			lastErr = res.err
 			// If all attempts we started have failed AND we've reached the limit
 			if received == ht.maxAttempts {
-				return nil, lastErr
+				return res.res, lastErr
 			}
 		case <-timeout:
 			started++

--- a/disco/http_transport_test.go
+++ b/disco/http_transport_test.go
@@ -54,7 +54,50 @@ func TestHedgedTransport_MultipleAttempts(t *testing.T) {
 	t.Logf("Total requests: %d, Total duration: %v", count, duration)
 }
 
-func TestHedgedTransport_AllErrors(t *testing.T) {
+func TestHedgedTransport_5XXErrors(t *testing.T) {
+	var requestCount int32
+	hedgeTimeout := 50 * time.Millisecond
+	maxAttempts := 7
+
+	// Create a slow test server that would require 3 hedged attempts to succeed
+	// with the given timeouts, except this time it returns 5xx errors instead of timing out.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+
+		if count := atomic.LoadInt32(&requestCount); count >= 3 {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success"))
+			return
+		}
+
+		w.WriteHeader(http.StatusGatewayTimeout)
+		w.Write([]byte("temporary server error"))
+	}))
+	defer ts.Close()
+
+	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.URL, nil)
+
+	start := time.Now()
+	resp, err := transport.RoundTrip(req)
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	count := atomic.LoadInt32(&requestCount)
+	var expectedAttempts int32 = 3 // With the given timings, we expect 3 attempts
+	if count != expectedAttempts {
+		t.Errorf("Expected %d requests to be made, but got %d", expectedAttempts, count)
+	}
+
+	t.Logf("Total requests: %d, Total duration: %v", count, duration)
+}
+
+func TestHedgedTransport_NoResponseEver(t *testing.T) {
 	var requestCount int32
 	hedgeTimeout := 30 * time.Millisecond
 	maxAttempts := 3

--- a/disco/http_transport_test.go
+++ b/disco/http_transport_test.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2017, 2025
+
+package disco
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHedgedTransport_MultipleAttempts(t *testing.T) {
+	var requestCount int32
+	hedgeTimeout := 50 * time.Millisecond
+	maxAttempts := 7
+
+	// Create a slow test server that would require 3 hedged attempts to succeed
+	// with the given timeouts.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+
+		if count := atomic.LoadInt32(&requestCount); count >= 3 {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success"))
+			return
+		}
+
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.URL, nil)
+
+	start := time.Now()
+	resp, err := transport.RoundTrip(req)
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	count := atomic.LoadInt32(&requestCount)
+	var expectedAttempts int32 = 3 // With the given timings, we expect 3 attempts
+	if count != expectedAttempts {
+		t.Errorf("Expected %d requests to be made, but got %d", expectedAttempts, count)
+	}
+
+	t.Logf("Total requests: %d, Total duration: %v", count, duration)
+}
+
+func TestHedgedTransport_AllErrors(t *testing.T) {
+	var requestCount int32
+	hedgeTimeout := 30 * time.Millisecond
+	maxAttempts := 3
+
+	// Create a slow test server that would require 3 hedged attempts to succeed
+	// with the given timeouts.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+	start := time.Now()
+	resp, err := transport.RoundTrip(req)
+	duration := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Expected context.DeadlineExceeded error, got %T", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	count := atomic.LoadInt32(&requestCount)
+	var expectedAttempts = int32(maxAttempts) // With the given timings, we expect 3 attempts
+	if count != expectedAttempts {
+		t.Errorf("Expected %d requests to be made, but got %d", expectedAttempts, count)
+	}
+
+	t.Logf("Total requests: %d, Total duration: %v", count, duration)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-svchost
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 


### PR DESCRIPTION
## Description

Service discovery now implements a hedged request strategy, where the service discovery request is repeated up to 7 times at 1500 ms intervals until the server responds.

## Testing plan

You can import this package into terraform and simulate server latency using a local HCPT service and observe multiple requests, up to the original timeout of 11 seconds, being attempted by `terraform init`

From the terraform repo

`$ go mod edit -replace github.com/hashicorp/terraform-svchost=../terraform-svchost`

