### PR TITLE
discovery: Don't cancel request context before response body can be read

### DIFF
--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -4,7 +4,9 @@ package disco
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -16,6 +18,19 @@ const DefaultUserAgent = "terraform-svchost/1.0"
 type userAgentRoundTripper struct {
 	innerRt   http.RoundTripper
 	userAgent string
+}
+
+type result struct {
+	resp   *http.Response
+	cancel context.CancelFunc
+}
+
+// hedgedBodyWrapper is an io.ReadCloser that cancels the associated hedgedTransport
+// context when closed, ensuring that any resources associated with the winning
+// request are cleaned up when the user is done with the response.
+type hedgedBodyWrapper struct {
+	io.ReadCloser
+	cancel context.CancelFunc
 }
 
 // hedgedTransport implements a hedged HTTP transport that sends multiple
@@ -48,71 +63,128 @@ func newUserAgentTransport(userAgent string, innerRt http.RoundTripper) http.Rou
 }
 
 // RoundTrip implements the http.RoundTripper interface for hedgedTransport
+// it sends the initial request immediately and then sends additional
+// requests if previous ones take too long, returning the first successful
+// response or the first error if all attempts fail.
 func (ht *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// We use a shared context to cancel all outstanding requests
-	// once the first one returns successfully.
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
+	reqctx := req.Context()
 
-	type result struct {
-		res *http.Response
-		err error
-	}
+	// Channel for receiving the first successful response
+	results := make(chan *result, 1)
 
-	// Buffer the channel to prevent goroutine leaks.
-	results := make(chan result, ht.maxAttempts)
+	// Buffered channel to track all possible errors. We only return an error if ALL attempts fail.
+	errors := make(chan error, ht.maxAttempts)
 
-	runAttempt := func() {
-		outReq := req.Clone(ctx)
-		resp, err := ht.transport.RoundTrip(outReq)
+	var (
+		mu       sync.Mutex
+		cancels  = make([]context.CancelFunc, ht.maxAttempts)
+		finished bool
+		firstErr error
+	)
 
-		// handle the error case downstream
-		select {
-		case results <- result{resp, err}:
-		case <-ctx.Done():
-			// If context is canceled, someone else won.
-			// Ensure we don't leak the response body.
-			if resp != nil && resp.Body != nil {
-				resp.Body.Close()
+	abort := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		finished = true
+		for _, c := range cancels {
+			if c != nil {
+				c()
 			}
 		}
 	}
-	go runAttempt()
-	var lastErr error
-	started := 1
-	received := 0
 
+	spawn := func(idx int) {
+		mu.Lock()
+		subctx, cancel := context.WithCancel(reqctx)
+		cancels[idx] = cancel
+		mu.Unlock()
+
+		go func(subctx context.Context, c context.CancelFunc, idx int) {
+			spawnreq := req.Clone(subctx)
+			resp, err := ht.transport.RoundTrip(spawnreq)
+
+			if err != nil {
+				errors <- err
+				return
+			}
+
+			mu.Lock()
+			if finished {
+				// The main loop aborted OR another request already won.
+				// We must close this body immediately to prevent a leak.
+				mu.Unlock()
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
+				return
+			}
+
+			finished = true
+
+			// Cancel all other in-flight requests
+			for j, otherCancel := range cancels {
+				if otherCancel != nil && j != idx {
+					otherCancel()
+				}
+			}
+			mu.Unlock()
+
+			results <- &result{resp: resp, cancel: c}
+		}(subctx, cancel, idx)
+	}
+
+	spawned := 0
+	errorsReceived := 0
+
+	// Fire attempt 0 immediately
+	spawn(spawned)
+	spawned++
+
+	// Centralized orchestration loop
 	for {
-		var timeout <-chan time.Time
-
-		// if we haven't started all attempts, use ht.timeout.
-		// if we have, wait indefinitely (effectively until context cancel).
-		if started < ht.maxAttempts {
-			timeout = time.After(ht.timeout)
-		}
 		select {
+		case <-reqctx.Done():
+			abort()
+			return nil, reqctx.Err()
+
 		case res := <-results:
-			received++
-			// Retry on error (no response) or 5xx
-			if res.err == nil && res.res.StatusCode < 500 {
-				return res.res, nil
+			res.resp.Body = &hedgedBodyWrapper{
+				ReadCloser: res.resp.Body,
+				cancel:     res.cancel,
 			}
-			// Don't leak response bodies
-			if res.res != nil && res.res.Body != nil {
-				res.res.Body.Close()
+			return res.resp, nil
+
+		case err := <-errors:
+			errorsReceived++
+			if firstErr == nil {
+				firstErr = err
 			}
-			lastErr = res.err
-			// If all attempts we started have failed AND we've reached the limit
-			if received == ht.maxAttempts {
-				return res.res, lastErr
+
+			// Only return an error if ALL hedges failed
+			if errorsReceived == ht.maxAttempts {
+				abort()
+				return nil, firstErr
 			}
-		case <-timeout:
-			started++
-			go runAttempt()
-		case <-req.Context().Done():
-			return nil, req.Context().Err()
+
+			// If a request fails, don't wait for the timer. Spawn the next hedge immediately.
+			if spawned < ht.maxAttempts {
+				spawn(spawned)
+				spawned++
+			}
+
+		case <-time.After(ht.timeout):
+			if spawned < ht.maxAttempts {
+				spawn(spawned)
+				spawned++
+			}
 		}
 	}
+}
+
+func (w *hedgedBodyWrapper) Close() error {
+	err := w.ReadCloser.Close()
+	w.cancel() // Finally clean up the winner's context
+	return err
 }
 
 // RoundTrip implements the http.RoundTripper interface for userAgentRoundTripper

--- a/disco/http_transport.go
+++ b/disco/http_transport.go
@@ -36,6 +36,9 @@ type hedgedBodyWrapper struct {
 // hedgedTransport implements a hedged HTTP transport that sends multiple
 // requests if a previous request takes too long, with a specified timeout
 // between attempts.
+// Note: As always, it's necessary to close any non-nil response body
+// in order to avoid leaking resources. This is the mechanism by which
+// the successful request context is finally canceled.
 type hedgedTransport struct {
 	// Transport is the underlying RT used to actually make the requests.
 	transport http.RoundTripper

--- a/disco/http_transport_test.go
+++ b/disco/http_transport_test.go
@@ -5,6 +5,7 @@ package disco
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -14,7 +15,7 @@ import (
 
 func TestHedgedTransport_MultipleAttempts(t *testing.T) {
 	var requestCount int32
-	hedgeTimeout := 50 * time.Millisecond
+	hedgeTimeout := 5 * time.Millisecond
 	maxAttempts := 7
 
 	// Create a slow test server that would require 3 hedged attempts to succeed
@@ -34,16 +35,25 @@ func TestHedgedTransport_MultipleAttempts(t *testing.T) {
 
 	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
 
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.URL, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
 
 	start := time.Now()
+	t.Log("Starting roundtrip")
 	resp, err := transport.RoundTrip(req)
 	duration := time.Since(start)
+
+	if resp != nil && resp.Body != nil {
+		t.Cleanup(func() {
+			resp.Body.Close()
+		})
+	}
 
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
-	defer resp.Body.Close()
 
 	count := atomic.LoadInt32(&requestCount)
 	var expectedAttempts int32 = 3 // With the given timings, we expect 3 attempts
@@ -54,53 +64,10 @@ func TestHedgedTransport_MultipleAttempts(t *testing.T) {
 	t.Logf("Total requests: %d, Total duration: %v", count, duration)
 }
 
-func TestHedgedTransport_5XXErrors(t *testing.T) {
+func TestHedgedTransport_AllFail(t *testing.T) {
 	var requestCount int32
-	hedgeTimeout := 50 * time.Millisecond
+	hedgeTimeout := 5 * time.Millisecond
 	maxAttempts := 7
-
-	// Create a slow test server that would require 3 hedged attempts to succeed
-	// with the given timeouts, except this time it returns 5xx errors instead of timing out.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&requestCount, 1)
-
-		if count := atomic.LoadInt32(&requestCount); count >= 3 {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("success"))
-			return
-		}
-
-		w.WriteHeader(http.StatusGatewayTimeout)
-		w.Write([]byte("temporary server error"))
-	}))
-	defer ts.Close()
-
-	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
-
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", ts.URL, nil)
-
-	start := time.Now()
-	resp, err := transport.RoundTrip(req)
-	duration := time.Since(start)
-
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-	defer resp.Body.Close()
-
-	count := atomic.LoadInt32(&requestCount)
-	var expectedAttempts int32 = 3 // With the given timings, we expect 3 attempts
-	if count != expectedAttempts {
-		t.Errorf("Expected %d requests to be made, but got %d", expectedAttempts, count)
-	}
-
-	t.Logf("Total requests: %d, Total duration: %v", count, duration)
-}
-
-func TestHedgedTransport_NoResponseEver(t *testing.T) {
-	var requestCount int32
-	hedgeTimeout := 30 * time.Millisecond
-	maxAttempts := 3
 
 	// Create a slow test server that would require 3 hedged attempts to succeed
 	// with the given timeouts.
@@ -108,9 +75,11 @@ func TestHedgedTransport_NoResponseEver(t *testing.T) {
 		atomic.AddInt32(&requestCount, 1)
 		<-r.Context().Done()
 	}))
-	defer ts.Close()
+	t.Cleanup(func() {
+		ts.Close()
+	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
@@ -119,12 +88,13 @@ func TestHedgedTransport_NoResponseEver(t *testing.T) {
 	resp, err := transport.RoundTrip(req)
 	duration := time.Since(start)
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Expected context.DeadlineExceeded error, got %T", err)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+		t.Errorf("Unexpected body in test response")
 	}
 
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Expected context.DeadlineExceeded error, got %T", err)
 	}
 
 	count := atomic.LoadInt32(&requestCount)
@@ -134,4 +104,146 @@ func TestHedgedTransport_NoResponseEver(t *testing.T) {
 	}
 
 	t.Logf("Total requests: %d, Total duration: %v", count, duration)
+}
+
+func TestHedgedTransport_LastResponseSucceeds(t *testing.T) {
+	var requestCount int32
+	hedgeTimeout := 5 * time.Millisecond
+	maxAttempts := 7
+
+	// Create a slow test server that would require 3 hedged attempts to succeed
+	// with the given timeouts.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+
+		if count := atomic.LoadInt32(&requestCount); count == int32(maxAttempts) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success"))
+			return
+		}
+
+		<-r.Context().Done()
+	}))
+	t.Cleanup(func() {
+		ts.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	transport := newHedgedHTTPTransport(http.DefaultTransport, hedgeTimeout, maxAttempts)
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+	start := time.Now()
+	resp, err := transport.RoundTrip(req)
+	duration := time.Since(start)
+
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	} else {
+		t.Errorf("Expected a response body, got nil")
+	}
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %T", err)
+	}
+
+	count := atomic.LoadInt32(&requestCount)
+	var expectedAttempts = int32(maxAttempts) // With the given timings, we expect 3 attempts
+	if count != expectedAttempts {
+		t.Errorf("Expected %d requests to be made, but got %d", expectedAttempts, count)
+	}
+
+	t.Logf("Total requests: %d, Total duration: %v", count, duration)
+}
+
+// contextAwareBody simulates the behavior of a real net/http response body:
+// reads fail once the request context is canceled. In production, this happens
+// because the underlying TCP connection is tied to the request context.
+type contextAwareBody struct {
+	ctx    context.Context
+	data   []byte
+	offset int
+}
+
+func (b *contextAwareBody) Read(p []byte) (int, error) {
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if b.offset >= len(b.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, b.data[b.offset:])
+	b.offset += n
+	return n, nil
+}
+
+func (b *contextAwareBody) Close() error {
+	return nil
+}
+
+// slowBodyTransport is a fake RoundTripper that controls exactly which attempt
+// succeeds. Attempts before successAfter block until their context is canceled
+// (simulating a slow upstream). The attempt that matches successAfter returns
+// a 200 with a context-aware body.
+type slowBodyTransport struct {
+	requestCount int32
+	successAfter int32
+}
+
+func (t *slowBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	count := atomic.AddInt32(&t.requestCount, 1)
+
+	if count >= t.successAfter {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body: &contextAwareBody{
+				ctx:  req.Context(),
+				data: []byte("success"),
+			},
+		}, nil
+	}
+
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+// TestHedgedTransport_BodyReadableAfterReturn demonstrates a bug found in
+// hedgedTransport.RoundTrip: the shared context was canceled via defer before
+// the caller has a chance to read the response body. Because the winning
+// response's body is bound to that context, sometimes reading the body would
+// fail with "context canceled".
+func TestHedgedTransport_BodyReadableAfterReturn(t *testing.T) {
+	transport := &slowBodyTransport{successAfter: 2}
+
+	// 10ms hedge delay means the second attempt fires 10ms after the first.
+	// 5 max attempts gives plenty of room (we only need 2).
+	hedged := newHedgedHTTPTransport(transport, 10*time.Millisecond, 5)
+
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := hedged.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	// This is where the bug manifests: by the time we read the body,
+	// defer cancel() in hedgedTransport.RoundTrip has already fired,
+	// canceling the context that the response body depends on.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if string(body) != "success" {
+		t.Fatalf("expected body %q, got %q", "success", string(body))
+	}
 }


### PR DESCRIPTION
## Description

There is a race condition in the new hedgedHTTPTransport between the caller reading the body and the request context being canceled by the round tripper.

To recreate the bug, I had to use a response body mock that checked the context before reading in a mock round tripper. Normal test responses appeared to be read and cached quickly by net/http before the context was canceled.

The fix was to track individual cancels, calling them all except the winning request when returning from the round tripper, and finally canceling the last context when the response body is closed.